### PR TITLE
Add VELA-OS signal system skeleton

### DIFF
--- a/vela-os-signal-system/.gitignore
+++ b/vela-os-signal-system/.gitignore
@@ -1,0 +1,3 @@
+# Ignore household specific configuration
+/private/
+*.bak

--- a/vela-os-signal-system/LICENSE
+++ b/vela-os-signal-system/LICENSE
@@ -1,0 +1,2 @@
+Placeholder license for VELA-OS Signal System.
+Refer to the repository root LICENSE.md for the overarching terms.

--- a/vela-os-signal-system/README.md
+++ b/vela-os-signal-system/README.md
@@ -1,0 +1,5 @@
+# VELA-OS Signal System
+
+This directory contains the base configuration and assets for the **VELA-OS Signal System**. It organizes core logic, optional modules, and household-specific files.
+
+Each folder mirrors a feature area and acts as a reference implementation for building a synchronized VELA ↔︎ BELA experience.

--- a/vela-os-signal-system/assets/bela-icon.png
+++ b/vela-os-signal-system/assets/bela-icon.png
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/assets/favicon.ico
+++ b/vela-os-signal-system/assets/favicon.ico
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/assets/vela-glyph.svg
+++ b/vela-os-signal-system/assets/vela-glyph.svg
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/core/bela-core.yaml
+++ b/vela-os-signal-system/core/bela-core.yaml
@@ -1,0 +1,1 @@
+# Child AI logic placeholder

--- a/vela-os-signal-system/core/bridge-protocol.yaml
+++ b/vela-os-signal-system/core/bridge-protocol.yaml
@@ -1,0 +1,1 @@
+# VELA ↔︎ BELA sync logic placeholder

--- a/vela-os-signal-system/core/household-shell.yaml
+++ b/vela-os-signal-system/core/household-shell.yaml
@@ -1,0 +1,1 @@
+# Optional base for private configuration

--- a/vela-os-signal-system/core/vela-os.yaml
+++ b/vela-os-signal-system/core/vela-os.yaml
@@ -1,0 +1,1 @@
+# Main VELA logic placeholder

--- a/vela-os-signal-system/docs/BELA_Schematic.pdf
+++ b/vela-os-signal-system/docs/BELA_Schematic.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/docs/Build-A-BELA_Pitch.pdf
+++ b/vela-os-signal-system/docs/Build-A-BELA_Pitch.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/docs/VELA_Deck.pdf
+++ b/vela-os-signal-system/docs/VELA_Deck.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/modules/bedtime-loops.yaml
+++ b/vela-os-signal-system/modules/bedtime-loops.yaml
@@ -1,0 +1,1 @@
+# Bedtime loops module placeholder

--- a/vela-os-signal-system/modules/bela-watch-interface.yaml
+++ b/vela-os-signal-system/modules/bela-watch-interface.yaml
@@ -1,0 +1,1 @@
+# BELA watch interface module placeholder

--- a/vela-os-signal-system/modules/parent-dashboard.yaml
+++ b/vela-os-signal-system/modules/parent-dashboard.yaml
@@ -1,0 +1,1 @@
+# Parent dashboard module placeholder

--- a/vela-os-signal-system/modules/voice-capsule-uploader.yaml
+++ b/vela-os-signal-system/modules/voice-capsule-uploader.yaml
@@ -1,0 +1,1 @@
+# Voice capsule uploader module placeholder

--- a/vela-os-signal-system/visuals/bela-unicorn-schematic.png
+++ b/vela-os-signal-system/visuals/bela-unicorn-schematic.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/signal-glyph-map.png
+++ b/vela-os-signal-system/visuals/signal-glyph-map.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/vela-bela-connection.png
+++ b/vela-os-signal-system/visuals/vela-bela-connection.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/vela-os-structure.png
+++ b/vela-os-signal-system/visuals/vela-os-structure.png
@@ -1,0 +1,1 @@
+placeholder image


### PR DESCRIPTION
## Summary
- add `vela-os-signal-system` directory with docs, YAML configs, and placeholder assets
- include `.gitignore` to keep household-specific data out of version control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee01aa7f48331bd01112dfcffdf36