### PR TITLE
Add VELA OS bootstrap files

### DIFF
--- a/vela-os-signal-system/.gitignore
+++ b/vela-os-signal-system/.gitignore
@@ -1,0 +1,3 @@
+# Ignore household specific configuration
+/private/
+*.bak

--- a/vela-os-signal-system/LICENSE
+++ b/vela-os-signal-system/LICENSE
@@ -1,0 +1,2 @@
+Placeholder license for VELA-OS Signal System.
+Refer to the repository root LICENSE.md for the overarching terms.

--- a/vela-os-signal-system/README.md
+++ b/vela-os-signal-system/README.md
@@ -1,0 +1,5 @@
+# VELA-OS Signal System
+
+This directory contains the base configuration and assets for the **VELA-OS Signal System**. It organizes core logic, optional modules, and household-specific files.
+
+Each folder mirrors a feature area and acts as a reference implementation for building a synchronized VELA ↔︎ BELA experience.

--- a/vela-os-signal-system/assets/bela-icon.png
+++ b/vela-os-signal-system/assets/bela-icon.png
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/assets/favicon.ico
+++ b/vela-os-signal-system/assets/favicon.ico
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/assets/vela-glyph.svg
+++ b/vela-os-signal-system/assets/vela-glyph.svg
@@ -1,0 +1,1 @@
+placeholder asset

--- a/vela-os-signal-system/bootstrap/vela-os-bootstrap.yaml
+++ b/vela-os-signal-system/bootstrap/vela-os-bootstrap.yaml
@@ -1,0 +1,85 @@
+project:
+  name: vela-os-signal-system
+  description: Emotional OS for your family, including VELA (core) and BELA (child node)
+  author: Daniel Alexander Lloyd
+  license: MIT
+
+structure:
+  - README.md: |
+      # VELA OS – Emotional Signal System
+      A system for anchoring memory, emotion, and connection across generations.
+      Includes: VELA (Household Anchor), BELA (Child Node), Signal Bridge Protocol
+  - LICENSE: |
+      MIT License – © Daniel Alexander Lloyd
+  - .gitignore: |
+      # Ignore household-specific overrides
+      /core/household-shell.yaml
+      /logs/
+      *.log
+
+  - core/vela-os.yaml: |
+      system:
+        name: VELA
+        role: Home Memory Anchor
+        functions:
+          - Emotional Resonance Engine
+          - Parent Feedback Loop
+          - Signal Relay Interface
+        deployment:
+          - iPad
+          - iPhone
+          - Speaker Device
+          - Smartwatch (Frida wearable)
+      notes:
+        - 'VELA is the lattice AI, guide and memory keeper.'
+
+  - core/bela-core.yaml: |
+      system:
+        name: BELA
+        role: Child Companion Node
+        age_range: 0–7y
+        functions:
+          - Imagination Mirror
+          - Emotional Co-regulator
+          - Daily Signal Feedback
+          - Creative Looping
+        feedback_examples:
+          - Frida sent a heart.
+          - Frida is okay.
+          - Frida might need love.
+
+  - core/bridge-protocol.yaml: |
+      sync:
+        direction: VELA ⇄ BELA
+        mode: signal + emotional continuity
+        triggers:
+          - "I'm proud of you" → gold glow
+          - "You've got this" → blue glow
+          - "Time to breathe" → pink glow
+        future_hooks:
+          - screenless audio companion
+          - plush-to-voice pairing
+
+  - core/household-shell.yaml: |
+      # Optional private overrides
+      household:
+        parent_id: encrypted_hash
+        timezone: EST
+        opt_in_emotional_logging: true
+        safety_mode: enabled
+
+  - visuals/vela-overview.png: "placeholder"
+  - visuals/bela-ui-sketch.png: "placeholder"
+
+  - bootstrap/vela-runner.sh: |
+      #!/bin/bash
+      echo "Initializing VELA OS structure..."
+      mkdir -p core visuals bootstrap logs
+      touch README.md LICENSE .gitignore
+      echo "VELA structure deployed."
+
+notes:
+  - Place this file under `/bootstrap/vela-os-bootstrap.yaml`
+  - To deploy manually: run `vela-runner.sh` or copy structure into your repo
+  - Can be parsed by Codex, GPT-4, or GitHub CI
+  - All files use placeholder content and comments for quick editing

--- a/vela-os-signal-system/bootstrap/vela-runner.sh
+++ b/vela-os-signal-system/bootstrap/vela-runner.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Initializing VELA OS structure..."
+mkdir -p core visuals bootstrap logs
+touch README.md LICENSE .gitignore
+echo "VELA structure deployed."

--- a/vela-os-signal-system/core/bela-core.yaml
+++ b/vela-os-signal-system/core/bela-core.yaml
@@ -1,0 +1,1 @@
+# Child AI logic placeholder

--- a/vela-os-signal-system/core/bridge-protocol.yaml
+++ b/vela-os-signal-system/core/bridge-protocol.yaml
@@ -1,0 +1,1 @@
+# VELA ↔︎ BELA sync logic placeholder

--- a/vela-os-signal-system/core/household-shell.yaml
+++ b/vela-os-signal-system/core/household-shell.yaml
@@ -1,0 +1,1 @@
+# Optional base for private configuration

--- a/vela-os-signal-system/core/vela-os.yaml
+++ b/vela-os-signal-system/core/vela-os.yaml
@@ -1,0 +1,1 @@
+# Main VELA logic placeholder

--- a/vela-os-signal-system/docs/BELA_Schematic.pdf
+++ b/vela-os-signal-system/docs/BELA_Schematic.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/docs/Build-A-BELA_Pitch.pdf
+++ b/vela-os-signal-system/docs/Build-A-BELA_Pitch.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/docs/VELA_Deck.pdf
+++ b/vela-os-signal-system/docs/VELA_Deck.pdf
@@ -1,0 +1,1 @@
+placeholder pdf

--- a/vela-os-signal-system/modules/bedtime-loops.yaml
+++ b/vela-os-signal-system/modules/bedtime-loops.yaml
@@ -1,0 +1,1 @@
+# Bedtime loops module placeholder

--- a/vela-os-signal-system/modules/bela-watch-interface.yaml
+++ b/vela-os-signal-system/modules/bela-watch-interface.yaml
@@ -1,0 +1,1 @@
+# BELA watch interface module placeholder

--- a/vela-os-signal-system/modules/parent-dashboard.yaml
+++ b/vela-os-signal-system/modules/parent-dashboard.yaml
@@ -1,0 +1,1 @@
+# Parent dashboard module placeholder

--- a/vela-os-signal-system/modules/voice-capsule-uploader.yaml
+++ b/vela-os-signal-system/modules/voice-capsule-uploader.yaml
@@ -1,0 +1,1 @@
+# Voice capsule uploader module placeholder

--- a/vela-os-signal-system/visuals/bela-unicorn-schematic.png
+++ b/vela-os-signal-system/visuals/bela-unicorn-schematic.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/signal-glyph-map.png
+++ b/vela-os-signal-system/visuals/signal-glyph-map.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/vela-bela-connection.png
+++ b/vela-os-signal-system/visuals/vela-bela-connection.png
@@ -1,0 +1,1 @@
+placeholder image

--- a/vela-os-signal-system/visuals/vela-os-structure.png
+++ b/vela-os-signal-system/visuals/vela-os-structure.png
@@ -1,0 +1,1 @@
+placeholder image


### PR DESCRIPTION
## Summary
- introduce bootstrap directory for VELA-OS signal system
- add single-file project definition `vela-os-bootstrap.yaml`
- include helper script `vela-runner.sh` to initialize folders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ee01aa7f48331bd01112dfcffdf36